### PR TITLE
ClosePageFile Added

### DIFF
--- a/storage_mgr.c
+++ b/storage_mgr.c
@@ -83,3 +83,31 @@ extern RC openPageFile(char *fileName, SM_FileHandle *fHandle)
   // Return success code
   return returnCode;
 }
+
+extern RC closePageFile(SM_FileHandle *fHandle){
+// Check if the file handle is NULL or if the file is not initialized
+    openFile(fp, fHandle->fileName, "r+");
+    printf("************Closing Page File****************\n");
+    int returnCode = RC_OK;
+    if (fHandle == NULL || !fp) {
+        returnCode = RC_FILE_NOT_FOUND;
+        RC_message = "ERR: FILE DOES NOT EXIST!";
+        printError(*RC_message);
+        return returnCode;
+    }
+
+    // Close the file
+    int closeStatus= fclose(fHandle->mgmtInfo);
+
+    if(closeStatus==0){
+      returnCode = RC_OK;
+      RC_message = "CLOSED SUCCESFULLY";
+      printError(*RC_message);
+      return returnCode;
+    }else{
+      returnCode = RC_CLOSE_FILE_FAILED;
+      RC_message = "ERR: UNABLE TO CLOSE FILE";
+      printError(*RC_message);
+      return returnCode;
+    }
+}


### PR DESCRIPTION
 **closePageFile**

**Description:**

This function closes an open page file, releasing associated resources and invalidating the file handle.

**Prototype:**

```c
extern RC closePageFile(SM_FileHandle *fHandle);
```

**Parameters:**

* **fHandle:** A pointer to the file handle structure of the page file to be closed.

**Return Values:**

* **RC_OK:** The file was closed successfully.
* **RC_FILE_NOT_FOUND:** The specified file handle is NULL or invalid.
* **RC_CLOSE_FILE_FAILED:** An error occurred while closing the file.

**Steps:**

1. Checks if the file handle is NULL or invalid.
2. Opens the file again in "r+" mode to ensure it's accessible before closing.
3. Prints a message indicating that the file is being closed.
4. Closes the file using the `fclose` function.
5. Prints a success or error message based on the closing status.

**Error Handling:**

* Handles invalid file handles and file closure errors.
* Prints error messages using a `printError` function (not shown in the provided code).

**Usage Example:**

```c
SM_FileHandle fHandle;
// ... (open the file using openPageFile)

RC rc = closePageFile(&fHandle);

if (rc == RC_OK) {
    // File closed successfully
} else {
    // Handle error
}
```
